### PR TITLE
update extconf.rb and stmt.c

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -32,12 +32,7 @@ require 'mkmf'
 require 'rbconfig'
 
 if ENV["CUBRID"]
-	if Config::CONFIG["arch"] =~ /64/
-		cci_lib_path = ENV["CUBRID"] + "/lib64"
-	else
-		cci_lib_path = ENV["CUBRID"] + "/lib"
-	end
-
+	cci_lib_path = ENV["CUBRID"] + "/lib"
 	cci_inc_path = ENV["CUBRID"] + "/include"
 	
 	$INCFLAGS = ($INCFLAGS ? $INCFLAGS : "") + " -I" +  cci_inc_path

--- a/ext/stmt.c
+++ b/ext/stmt.c
@@ -49,7 +49,7 @@ cubrid_stmt_new(Connection *con, char *sql, int option)
   int handle, param_cnt; 
   T_CCI_ERROR error;
 
-  printf("%s\n", sql);
+  /* printf("%s\n", sql); */
 
   handle = cci_prepare(con->handle, sql, option, &error);
   if (handle < 0) {
@@ -947,9 +947,9 @@ cubrid_stmt_each(VALUE self)
 
   while(1) {
     row = cubrid_stmt_fetch(self);
-	if (NIL_P(row)) {
+    if (NIL_P(row)) {
       break;
-	}
+    }
     rb_yield(row);
   }
   
@@ -978,9 +978,9 @@ cubrid_stmt_each_hash(VALUE self)
 
   while(1) {
     row = cubrid_stmt_fetch_hash(self);
-	if (NIL_P(row)) {
+    if (NIL_P(row)) {
       break;
-	}
+    }
     rb_yield(row);
   }
   
@@ -1010,7 +1010,7 @@ cubrid_stmt_each_hash(VALUE self)
 VALUE
 cubrid_stmt_column_info(VALUE self)
 {
-  VALUE	desc;
+  VALUE    desc;
   int i;
   char col_name[MAX_STR_LEN];
   int datatype, precision, scale, nullable;


### PR DESCRIPTION
(1) change the cci_lib_path in extconf.rb: In CUBRID-8.4.1~9.1.0, the lib64 folder in $CUBRID is not exists.
(2) Remove the print of the sql clause in stmt.c
